### PR TITLE
Rename graph schema tables with graph_ prefix and add validation

### DIFF
--- a/src/disco/graph/extract.py
+++ b/src/disco/graph/extract.py
@@ -54,7 +54,7 @@ def get_vertex_data(
 
     The model node table (vertex_table) is keyed by (scenario_id, key),
     while the Graph structure uses (scenario_id, index). The mapping
-    from index -> key is stored in graph.vertices.
+    from index -> key is stored in graph_vertices.
 
     Semantics:
       - We start from graph.vertices (mapping table).
@@ -65,7 +65,7 @@ def get_vertex_data(
       - Missing model rows -> NaN/null, unless default_fill is provided.
 
     Requirements:
-      - graph.vertices must have columns:
+      - graph_vertices must have columns:
             scenario_id, index, key
       - vertex_table must have columns:
             scenario_id, key
@@ -265,12 +265,12 @@ def get_outbound_edge_data(
     Model edge tables are key-based:
       - scenario_id, source_key, target_key, ...
 
-    Structural edges in the graph schema are index-based:
-      - graph.edges with (scenario_id, layer_idx, source_idx, target_idx).
+    Structural edges are index-based:
+      - graph_edges with (scenario_id, layer_idx, source_idx, target_idx).
 
     We:
-      - Start from graph.edges (indices).
-      - Join vertices twice to map source_idx/target_idx -> source_key/target_key.
+      - Start from graph_edges (indices).
+      - Join graph_vertices twice to map source_idx/target_idx -> source_key/target_key.
       - LEFT OUTER JOIN the model edge table on (scenario_id, source_key, target_key).
       - Optionally filter by GraphMask on the source index.
       - Return a DataFrame indexed by:
@@ -380,12 +380,12 @@ def get_inbound_edge_data(
     Model edge tables are key-based:
       - scenario_id, source_key, target_key, ...
 
-    Structural edges in the graph schema are index-based:
-      - graph.edges with (scenario_id, layer_idx, source_idx, target_idx).
+    Structural edges are index-based:
+      - graph_edges with (scenario_id, layer_idx, source_idx, target_idx).
 
     We:
-      - Start from graph.edges (indices).
-      - Join vertices twice to map source_idx/target_idx -> source_key/target_key.
+      - Start from graph_edges (indices).
+      - Join graph_vertices twice to map source_idx/target_idx -> source_key/target_key.
       - LEFT OUTER JOIN the model edge table on (scenario_id, source_key, target_key).
       - Optionally filter by GraphMask on the *target* index.
       - Return a DataFrame indexed by:
@@ -490,7 +490,7 @@ def get_outbound_map(
 ) -> gb.Matrix:
     """
     Return a GraphBLAS Matrix for outbound edges in a given layer,
-    using the structural graph.edges table (index-based).
+    using the structural graph_edges table (index-based).
 
     - Rows: source_idx
     - Columns: target_idx
@@ -566,7 +566,7 @@ def get_inbound_map(
 ) -> gb.Matrix:
     """
     Return a GraphBLAS Matrix for inbound edges in a given layer,
-    using the structural graph.edges table (index-based).
+    using the structural graph_edges table (index-based).
 
     - Rows: source_idx
     - Columns: target_idx

--- a/src/disco/graph/graph_mask.py
+++ b/src/disco/graph/graph_mask.py
@@ -42,7 +42,7 @@ class GraphMask:
     # ------------------------------------------------------------------ #
     def ensure_persisted(self, session: Session) -> None:
         """
-        Ensure the mask is present in graph.vertex_masks.
+        Ensure the mask is present in graph_vertex_masks.
 
         - If it's not stored yet:
             - Write (scenario_id, mask_id, vertex_index, updated_at) rows.
@@ -88,7 +88,7 @@ class GraphMask:
     # ------------------------------------------------------------------ #
     def _write_full(self, session: Session) -> None:
         """
-        Write the full contents of this mask into graph.vertex_masks.
+        Write the full contents of this mask into graph_vertex_masks.
 
         Strategy:
         - DELETE any existing rows for (scenario_id, mask_id).

--- a/src/disco/model/spec.py
+++ b/src/disco/model/spec.py
@@ -29,6 +29,10 @@ class SimProcSpec(BaseModel):
         s = v.strip()
         if not s:
             raise ValueError("edge-data-table may not be empty/whitespace")
+        if s.lower().startswith("graph_"):
+            raise ValueError(
+                "edge-data-table may not start with 'graph_' (reserved for graph infrastructure tables)"
+            )
         return s
 
 
@@ -73,6 +77,10 @@ class NodeTypeSpec(BaseModel):
         s = v.strip()
         if not s:
             raise ValueError("node-data-table may not be empty/whitespace")
+        if s.lower().startswith("graph_"):
+            raise ValueError(
+                "node-data-table may not start with 'graph_' (reserved for graph infrastructure tables)"
+            )
         return s
 
     # noinspection PyNestedDecorators
@@ -248,6 +256,10 @@ class ModelSpec(BaseModel):
         s = v.strip()
         if not s:
             raise ValueError("default-edge-data-table may not be empty/whitespace")
+        if s.lower().startswith("graph_"):
+            raise ValueError(
+                "default-edge-data-table may not start with 'graph_' (reserved for graph infrastructure tables)"
+            )
         return s
 
     # noinspection PyNestedDecorators

--- a/tests/graph/test_extract.py
+++ b/tests/graph/test_extract.py
@@ -80,36 +80,21 @@ def _populate_vertices_and_edges(
     """
     Insert a small mapping of indices->keys and structural edges:
 
-      vertices (scenario_id, index, key, node_type):
-        (S1, 0, "A", "test")
-        (S1, 1, "B", "test")
-        (S1, 2, "C", "test")
+      graph_vertices (scenario_id, index, key):
+        (S1, 0, "A")
+        (S1, 1, "B")
+        (S1, 2, "C")
 
-      edges (scenario_id, layer_idx=0, source_idx, target_idx, weight):
+      graph_edges (scenario_id, layer_idx=0, source_idx, target_idx, weight):
         (S1, 0, 0 -> 1, weight=1.5)
         (S1, 0, 1 -> 2, weight=2.5)
     """
     session.execute(
         insert(vertices),
         [
-            {
-                "scenario_id": scenario_id,
-                "index": 0,
-                "key": "A",
-                "node_type": "test",  # <-- required by current schema
-            },
-            {
-                "scenario_id": scenario_id,
-                "index": 1,
-                "key": "B",
-                "node_type": "test",
-            },
-            {
-                "scenario_id": scenario_id,
-                "index": 2,
-                "key": "C",
-                "node_type": "test",
-            },
+            {"scenario_id": scenario_id, "index": 0, "key": "A"},
+            {"scenario_id": scenario_id, "index": 1, "key": "B"},
+            {"scenario_id": scenario_id, "index": 2, "key": "C"},
         ],
     )
 
@@ -122,7 +107,6 @@ def _populate_vertices_and_edges(
                 "source_idx": 0,
                 "target_idx": 1,
                 "weight": 1.5,
-                "name": "e_0_0_1",
             },
             {
                 "scenario_id": scenario_id,
@@ -130,7 +114,6 @@ def _populate_vertices_and_edges(
                 "source_idx": 1,
                 "target_idx": 2,
                 "weight": 2.5,
-                "name": "e_0_1_2",
             },
         ],
     )
@@ -143,17 +126,11 @@ def engine_session_and_model_tables() -> Iterator[
     Helper generator for tests.
 
     - Creates in-memory SQLite engine
-    - Applies schema_translate_map so "graph" schema is stripped
-    - Creates graph schema (scenarios, vertices, edges, ...)
+    - Creates graph tables (graph_scenarios, graph_vertices, graph_edges, ...)
     - Creates key-based model node/edge tables
     """
-    # Base in-memory SQLite engine
     engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
 
-    # IMPORTANT: strip the "graph" schema for SQLite
-    engine = engine.execution_options(schema_translate_map={"graph": None})
-
-    # Now all DDL/DML using schema="graph" becomes plain tables in "main"
     create_graph_schema(engine)
 
     node_data, edge_data = _create_model_tables(engine)

--- a/tests/model/test_spec.py
+++ b/tests/model/test_spec.py
@@ -131,3 +131,81 @@ def test_modelspec_default_edge_data_table_blank_rejected():
     d["default-edge-data-table"] = "   "
     with pytest.raises(ValidationError):
         ModelSpec.model_validate(d)
+
+
+# ---------------------------------------------------------------------------
+# graph_ prefix rejection
+# ---------------------------------------------------------------------------
+
+
+def test_modelspec_node_data_table_graph_prefix_rejected():
+    d = _base_model_dict_list_simprocs()
+    d["node-types"]["Warehouse"]["node-data-table"] = "graph_nodes"
+    with pytest.raises(ValidationError):
+        ModelSpec.model_validate(d)
+
+
+def test_modelspec_default_edge_data_table_graph_prefix_rejected():
+    d = _base_model_dict_list_simprocs()
+    d["default-edge-data-table"] = "graph_edges"
+    with pytest.raises(ValidationError):
+        ModelSpec.model_validate(d)
+
+
+def test_modelspec_simproc_edge_data_table_graph_prefix_rejected():
+    d = _base_model_dict_map_simprocs()
+    d["simprocs"]["demand"]["edge-data-table"] = "graph_demand_edges"
+    with pytest.raises(ValidationError):
+        ModelSpec.model_validate(d)
+
+
+# Standard infrastructure table names (graph_ prefix, exact names)
+
+def test_modelspec_node_data_table_graph_scenarios_rejected():
+    d = _base_model_dict_list_simprocs()
+    d["node-types"]["Warehouse"]["node-data-table"] = "graph_scenarios"
+    with pytest.raises(ValidationError):
+        ModelSpec.model_validate(d)
+
+
+def test_modelspec_node_data_table_graph_vertices_rejected():
+    d = _base_model_dict_list_simprocs()
+    d["node-types"]["Warehouse"]["node-data-table"] = "graph_vertices"
+    with pytest.raises(ValidationError):
+        ModelSpec.model_validate(d)
+
+
+def test_modelspec_default_edge_data_table_graph_edges_rejected():
+    d = _base_model_dict_list_simprocs()
+    d["default-edge-data-table"] = "graph_edges"
+    with pytest.raises(ValidationError):
+        ModelSpec.model_validate(d)
+
+
+def test_modelspec_node_data_table_graph_labels_rejected():
+    d = _base_model_dict_list_simprocs()
+    d["node-types"]["Warehouse"]["node-data-table"] = "graph_labels"
+    with pytest.raises(ValidationError):
+        ModelSpec.model_validate(d)
+
+
+def test_modelspec_node_data_table_graph_vertex_labels_rejected():
+    d = _base_model_dict_list_simprocs()
+    d["node-types"]["Warehouse"]["node-data-table"] = "graph_vertex_labels"
+    with pytest.raises(ValidationError):
+        ModelSpec.model_validate(d)
+
+
+def test_modelspec_node_data_table_graph_vertex_masks_rejected():
+    d = _base_model_dict_list_simprocs()
+    d["node-types"]["Warehouse"]["node-data-table"] = "graph_vertex_masks"
+    with pytest.raises(ValidationError):
+        ModelSpec.model_validate(d)
+
+
+def test_modelspec_graph_prefix_case_insensitive_rejected():
+    # Validation is case-insensitive: GRAPH_nodes should also be rejected
+    d = _base_model_dict_list_simprocs()
+    d["node-types"]["Warehouse"]["node-data-table"] = "GRAPH_nodes"
+    with pytest.raises(ValidationError):
+        ModelSpec.model_validate(d)


### PR DESCRIPTION
## Summary
This PR refactors the graph infrastructure to use explicit table naming with a `graph_` prefix instead of relying on a separate database schema. All graph tables are now prefixed with `graph_` (e.g., `graph_scenarios`, `graph_vertices`, `graph_edges`) and reside in the default schema. Additionally, validation is added to prevent model providers from accidentally defining tables that collide with the reserved `graph_` namespace.

## Key Changes

### Schema and Table Naming
- **Removed schema-based organization**: Changed from `schema="graph"` with unqualified table names to using the default schema with `graph_`-prefixed table names
- **Renamed all graph infrastructure tables**:
  - `scenarios` → `graph_scenarios`
  - `vertices` → `graph_vertices`
  - `edges` → `graph_edges`
  - `labels` → `graph_labels`
  - `vertex_labels` → `graph_vertex_labels`
  - `vertex_masks` → `graph_vertex_masks`
- **Updated all foreign key references** to use the new table names
- **Removed schema translation logic**: Eliminated `schema_translate_map` workarounds for SQLite compatibility
- **Simplified schema creation**: Removed PostgreSQL-specific schema creation logic since all tables now use the default schema

### Validation and Guards
- **Added `_check_no_graph_prefix_tables()` helper** in `orm.py` to validate that model ORM metadata doesn't define tables starting with `graph_` (case-insensitive)
- **Added validation in `spec.py`** for three table name fields:
  - `node-data-table`: rejects names starting with `graph_`
  - `edge-data-table`: rejects names starting with `graph_`
  - `default-edge-data-table`: rejects names starting with `graph_`
- **Validation is case-insensitive** to catch variations like `GRAPH_nodes`

### Testing
- **Added 10 new test cases** covering:
  - Rejection of `graph_` prefix in node/edge data table names
  - Rejection of specific reserved table names (`graph_scenarios`, `graph_vertices`, `graph_edges`, `graph_labels`, `graph_vertex_labels`, `graph_vertex_masks`)
  - Case-insensitive validation

### Documentation Updates
- Updated docstrings and comments throughout to reference new table names
- Updated error messages to reference `graph_scenarios` instead of `graph.scenarios`, etc.
- Clarified that graph tables are "prefixed with `graph_`" rather than in a separate schema

## Implementation Details
- The validation guards are applied at two points:
  1. When loading metadata from a provider reference
  2. When reflecting tables from an existing database
- This ensures model definitions cannot accidentally collide with graph infrastructure regardless of how they're provided
- All existing functionality is preserved; this is purely a naming and organization change

https://claude.ai/code/session_01RKvyzfPDRJRFrpQs5Uw2AH