### PR TITLE
Fix incidence matrix storage to exclude zero values

### DIFF
--- a/src/disco/partitioning.py
+++ b/src/disco/partitioning.py
@@ -316,7 +316,7 @@ class Partitioning:
         metastore.update_key(self._manifest_path(self.partitioning_id), self.manifest_list())
 
         for i, ns in enumerate(self.node_specs):
-            row_vec = self.incidence[i, :].new()
+            row_vec = self.incidence[i, :].select("!=", 0).new()
             metastore.update_key(
                 self._node_assignments_path(self.partitioning_id, ns.partition, ns.node_name),
                 row_vec,
@@ -377,10 +377,11 @@ class Partitioning:
                 raise PartitioningCorruptError(
                     f"partitioning '{partitioning_id}': assignments for node '{ns.node_name}' is not a graphblas.Vector"
                 )
-            idx, _ = v.to_coo()
-            if idx.size:
-                rows.extend([i] * int(idx.size))
-                cols.extend(idx.tolist())
+            idx, vals = v.to_coo()
+            true_idx = idx[vals != 0]
+            if true_idx.size:
+                rows.extend([i] * int(true_idx.size))
+                cols.extend(true_idx.tolist())
 
         incidence = gb.Matrix.from_coo(
             rows,


### PR DESCRIPTION
## Summary
This PR fixes the incidence matrix serialization and deserialization to properly handle and exclude zero values from the sparse matrix representation.

## Key Changes
- **Store operation**: Filter out zero values when extracting row vectors from the incidence matrix before persisting to metastore using `.select("!=", 0)`
- **Load operation**: Extract both indices and values from COO format, then filter indices to only include positions where values are non-zero before reconstructing the incidence matrix

## Implementation Details
The changes ensure consistency in how sparse matrices are handled:
- When storing, the row vector is filtered to remove explicit zeros before serialization
- When loading, the COO representation is properly filtered by checking the actual values array, ensuring only non-zero entries are included in the reconstructed incidence matrix
- This prevents unnecessary storage of zero entries and ensures the incidence matrix maintains the expected sparse structure

https://claude.ai/code/session_01X9gYffYseCemzZXpshzEGC