### PR TITLE
Avoid deprecated utcnow in graph timestamps

### DIFF
--- a/ENGINEERING_SPEC.md
+++ b/ENGINEERING_SPEC.md
@@ -1635,7 +1635,8 @@ updated_at    TIMESTAMP NOT NULL
 - A *mask* is an arbitrary subset of vertices in a scenario, identified by a
   random `mask_id` (UUID).
 - For each `(scenario_id, mask_id)` there are zero or more `vertex_index` rows.
-- `updated_at` is touched whenever a mask is ensured/persisted.
+- `updated_at` is touched with a timezone-aware UTC timestamp whenever a mask
+  is ensured/persisted.
 
 `GraphMask` is responsible for populating and maintaining this table; it is used
 from `graph.extract` and other higher‑level helpers.
@@ -2017,7 +2018,7 @@ Responsibilities (in order):
    - If a row for `scenario_id` already exists and `replace=False`, raises
      `ValueError`.
    - If it exists and `replace=True`, calls `delete_scenario` first.
-   - Inserts `(scenario_id, created_at=utcnow(), description)`.
+   - Inserts `(scenario_id, created_at=<timezone-aware UTC timestamp>, description)`.
 
 4. **Write vertices** (`_store_vertices_for_scenario`):
 

--- a/src/disco/graph/db.py
+++ b/src/disco/graph/db.py
@@ -1,7 +1,7 @@
 # src/disco/graph/db.py
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Optional, Tuple
 
 import numpy as np
@@ -274,7 +274,7 @@ def store_graph(
                 f"Scenario {scenario_id!r} already exists in graph_scenarios"
             )
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     session.execute(
         insert(scenarios).values(
             scenario_id=scenario_id,

--- a/src/disco/graph/graph_mask.py
+++ b/src/disco/graph/graph_mask.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional, List
 
 import graphblas as gb
@@ -78,7 +78,7 @@ class GraphMask:
         """
         Remove all masks whose updated_at is older than the configured age.
         """
-        cutoff = datetime.utcnow() - timedelta(minutes=max_age_minutes)
+        cutoff = datetime.now(timezone.utc) - timedelta(minutes=max_age_minutes)
         session.execute(
             delete(vertex_masks).where(vertex_masks.c.updated_at < cutoff)
         )
@@ -95,7 +95,7 @@ class GraphMask:
         - INSERT one row per *True* vertex index.
         """
         indices, values = self.vector.to_coo()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         session.execute(
             delete(vertex_masks).where(
@@ -122,7 +122,7 @@ class GraphMask:
         """
         Bump updated_at for all rows of this mask to mark recent use.
         """
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         session.execute(
             update(vertex_masks)
             .where(

--- a/tests/graph/test_datetime_compat.py
+++ b/tests/graph/test_datetime_compat.py
@@ -1,0 +1,21 @@
+import ast
+from pathlib import Path
+
+
+def test_graph_modules_avoid_deprecated_utcnow() -> None:
+    root = Path(__file__).parents[2]
+    paths = [
+        root / "src" / "disco" / "graph" / "db.py",
+        root / "src" / "disco" / "graph" / "graph_mask.py",
+    ]
+
+    for path in paths:
+        tree = ast.parse(path.read_text())
+        utcnow_lines = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "utcnow"
+        ]
+        assert utcnow_lines == []


### PR DESCRIPTION
## Summary
- Replace deprecated `datetime.utcnow()` calls in the graph DB and mask helpers with timezone-aware UTC timestamps.
- Update the graph spec to describe timezone-aware UTC scenario and mask timestamps.
- Add a static regression test to prevent `.utcnow()` calls from returning in the touched graph modules.

## Validation
- `git diff --check`
- `git diff --cached --check`
- `rg --line-number datetime\.utcnow|\.utcnow\( src ENGINEERING_SPEC.md` returned no matches
- Not run locally

Closes #43